### PR TITLE
fix(scenario-outlines): capture scenarioStepsToRun in closure

### DIFF
--- a/src/vitest/describe-feature.ts
+++ b/src/vitest/describe-feature.ts
@@ -144,7 +144,7 @@ export function describeFeature (
                     scenarioStepsToRun = []
                     scenarioTestCallback(scenarioStepsCallback, exampleVariables)
 
-                    scenarioToRun.push(() => {
+                    scenarioToRun.push(((steps) => () => {
                         describe(scenarioDescription, () => {
                             beforeAll(() => {
                                 beforeEachScenarioHook()
@@ -160,12 +160,12 @@ export function describeFeature (
                                 afterEachScenarioHook()
                             })
             
-                            test.each(scenarioStepsToRun)(`$key`, async (scenarioStep) => {
+                            test.each(steps)(`$key`, async (scenarioStep) => {
                                 await scenarioStep.fn()
                                 scenarioStep.step.isCalled = true
                             })
                         })
-                    })
+                    })([...scenarioStepsToRun]))
                 })
             }
         },


### PR DESCRIPTION
The "multiple examples" aspect of the scenario outline feature is broken. The synchronous loop over each of the examples causes the test runner to execute the test suite N times, but it does so on each iteration with the _last_ item of example data, rather than the _i_th item.

This change simply creates a closure around the current iteration's step functions, so that they aren't clobbered on the next go-around of the loop.