### PR TITLE
fix(before-after-hooks): await asynchronous before/after hooks

### DIFF
--- a/src/vitest/describe-feature.ts
+++ b/src/vitest/describe-feature.ts
@@ -73,18 +73,18 @@ export function describeFeature (
 
             scenarioToRun.push(() => {
                 describe(scenarioDescription, () => {
-                    beforeAll(() => {
-                        beforeEachScenarioHook()
+                    beforeAll(async () => {
+                        await beforeEachScenarioHook()
                     })
 
-                    afterAll(() => {
+                    afterAll(async () => {
                         ScenarioStateDetector 
                             .forScenario(foundScenario)
                             .checkIfStepWasCalled()
     
                         foundScenario.isCalled = true
 
-                        afterEachScenarioHook()
+                        await afterEachScenarioHook()
                     })
 
                     test.each(scenarioStepsToRun)(`$key`, async (scenarioStep) => {
@@ -146,18 +146,18 @@ export function describeFeature (
 
                     scenarioToRun.push(((steps) => () => {
                         describe(scenarioDescription, () => {
-                            beforeAll(() => {
-                                beforeEachScenarioHook()
+                            beforeAll(async () => {
+                                await beforeEachScenarioHook()
                             })
             
-                            afterAll(() => {
+                            afterAll(async () => {
                                 ScenarioStateDetector 
                                     .forScenario(foundScenario)
                                     .checkIfStepWasCalled()
                 
                                 foundScenario.isCalled = true
             
-                                afterEachScenarioHook()
+                                await afterEachScenarioHook()
                             })
             
                             test.each(steps)(`$key`, async (scenarioStep) => {
@@ -186,16 +186,16 @@ export function describeFeature (
     describe(feature.name, async () => {
         await featureFn(descibeFeatureParams)
 
-        beforeAll(() => {
-            beforeAllScenarioHook()
+        beforeAll(async () => {
+            await beforeAllScenarioHook()
         })
 
-        afterAll(() => {
+        afterAll(async () => {
             FeatureStateDetector
                 .forFeature(feature)
                 .checkNotCalledScenario()
             
-            afterAllScenarioHook()
+            await afterAllScenarioHook()
         })
 
         scenarioToRun.forEach((scenario) => scenario())


### PR DESCRIPTION
The type definitions for `[before|after][Each|All]Scenario` suggest that asynchronous functions are supported (see use of `MaybePromise`), but the test runner doesn't actually `await` them.

This means asynchronous test setup/teardown doesn't work reliably.

This PR simply adds the necessary `async/await` tweaks to ensure that any asynchronous effect of async before/after hooks are actually completed, before each test run begins.

Again, apologies for another proposed patch _without test coverage or reproduction steps_ 😅

I don't have very much time to work around my professional commitments, but I do want to help improve this library. @amiceli, if you're too busy to verify/validate this fix, please bear with me for a couple more days until I'm able to add proper test coverage.