### PR TITLE
feat: add global configuration

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,6 @@
-import { describeFeature } from './vitest/describe-feature'
-import { loadFeature } from './vitest/load-feature'
-
-export { loadFeature, describeFeature }
+export {
+    type VitestCucumberOptions,
+    setVitestCucumberConfiguration,
+} from './vitest/configuration'
+export { describeFeature } from './vitest/describe-feature'
+export { loadFeature } from './vitest/load-feature'

--- a/src/parser/__tests__/parser.spec.ts
+++ b/src/parser/__tests__/parser.spec.ts
@@ -8,6 +8,7 @@ import {
     OnlyOneFeatureError,
     TwiceBackgroundError,
 } from '../../errors/errors'
+import { getVitestCucumberConfiguration } from '../../vitest/configuration'
 import { describeFeature } from '../../vitest/describe-feature'
 import avalaibleLanguages from '../lang/lang.json'
 import { ScenarioOutline } from '../models/scenario'
@@ -25,7 +26,7 @@ describe(`GherkinParser`, () => {
     let parser: GherkinParser
 
     beforeEach(() => {
-        parser = new GherkinParser()
+        parser = new GherkinParser(getVitestCucumberConfiguration())
     })
 
     function getCurrentScenario(p: GherkinParser) {
@@ -256,7 +257,7 @@ describe(`GherkinParser`, () => {
 
     it(`should handle commented line`, () => {
         const featureTitle = `Awesome unit tests`
-        const newParser = new GherkinParser()
+        const newParser = new GherkinParser(getVitestCucumberConfiguration())
 
         newParser.addLine(`# Feature: ${featureTitle}`)
 
@@ -462,7 +463,7 @@ describe(`GherkinParser`, () => {
                 parser.addLine(`            Given I want another background`)
                 parser.addLine(``)
             }).toThrowError(new TwiceBackgroundError())
-            parser = new GherkinParser()
+            parser = new GherkinParser(getVitestCucumberConfiguration())
             expect(() => {
                 parser.addLine(`Feature: I use background`)
                 parser.addLine(`    Background:`)

--- a/src/parser/__tests__/readfile.spec.ts
+++ b/src/parser/__tests__/readfile.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import { getVitestCucumberConfiguration } from '../../vitest/configuration'
 import { type Step, StepTypes } from '../models/step'
 import { FeatureFileReader } from '../readfile'
 
@@ -6,6 +7,7 @@ describe(`Parse feature file`, async () => {
     const path = `src/parser/__tests__/readline.feature`
     const features = await FeatureFileReader.fromPath({
         featureFilePath: path,
+        options: getVitestCucumberConfiguration(),
     }).parseFile()
 
     const [feature] = features

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -6,6 +6,10 @@ import {
     OnlyOneFeatureError,
     TwiceBackgroundError,
 } from '../errors/errors'
+import type {
+    RequiredVitestCucumberOptions,
+    VitestCucumberOptions,
+} from '../vitest/configuration'
 import { type SpokenParser, SpokenParserFactory } from './lang/SpokenParser'
 import { Background } from './models/Background'
 import { Rule } from './models/Rule'
@@ -13,13 +17,15 @@ import type { StepAble } from './models/Stepable'
 import type { Taggable } from './models/Taggable'
 import { Feature } from './models/feature'
 import { type Example, Scenario, ScenarioOutline } from './models/scenario'
-import { Step, type StepDataTanle, StepTypes } from './models/step'
+import { Step, type StepDataTanle } from './models/step'
 
 type SteppableName = 'Scenario' | 'ScenarioOutline' | 'Background'
 
-export type ParserOptions = {
-    language?: string
-}
+export type ParserOptions = Pick<VitestCucumberOptions, 'language'>
+export type RequiredParserOptions = Pick<
+    RequiredVitestCucumberOptions,
+    'language'
+>
 
 enum FeatureActions {
     FEATURE = 'Feature',
@@ -74,10 +80,8 @@ export class GherkinParser {
         this.lastStep = null
     }
 
-    public constructor(options?: ParserOptions) {
-        this.spokenParser = SpokenParserFactory.fromLang(
-            options?.language || 'en',
-        )
+    public constructor(options: RequiredParserOptions) {
+        this.spokenParser = SpokenParserFactory.fromLang(options.language)
     }
 
     public hasFeature(line: string): boolean {

--- a/src/parser/readfile.ts
+++ b/src/parser/readfile.ts
@@ -1,17 +1,13 @@
 import fs from 'node:fs'
 import readline from 'node:readline'
-import { test, vi } from 'vitest'
-import {
-    FeatureFileNotFoundError,
-    VitestsCucumberError,
-} from '../errors/errors'
+import { FeatureFileNotFoundError } from '../errors/errors'
 import type { Feature } from './models/feature'
-import { GherkinParser, type ParserOptions } from './parser'
+import { GherkinParser, type RequiredParserOptions } from './parser'
 
 type FeatureFileReaderParams = {
     featureFilePath: string
     callerFileDir?: string | null
-    options?: ParserOptions
+    options: RequiredParserOptions
 }
 
 export class FeatureFileReader {

--- a/src/vitest/__tests__/configuration.spec.ts
+++ b/src/vitest/__tests__/configuration.spec.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { FeatureContentReader } from '../../__mocks__/FeatureContentReader.spec'
+import {
+    getVitestCucumberConfiguration,
+    setVitestCucumberConfiguration,
+} from '../configuration'
+import { describeFeature } from '../describe-feature'
+
+describe(`Ignore scenario with @ignore tag by default`, () => {
+    const feature = FeatureContentReader.fromString([
+        `Feature: detect uncalled rules`,
+        `    Scenario: Simple scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  It check I am executed`,
+        `    @ignore`,
+        `    Scenario: Ignored scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  Don't check if I am called    `,
+    ]).parseContent()
+
+    describeFeature(feature, ({ Scenario, AfterAllScenarios }) => {
+        AfterAllScenarios(() => {
+            expect(
+                feature.getScenarioByName(`Ignored scenario`)?.isCalled,
+            ).toBe(false)
+            expect(
+                feature
+                    .getScenarioByName(`Ignored scenario`)
+                    ?.matchTags([`ignore`]),
+            ).toBe(true)
+        })
+        Scenario(`Simple scenario`, ({ Given, Then }) => {
+            Given(`vitest-cucumber is running`, () => {})
+            Then(`It check I am executed`, () => {})
+        })
+    })
+})
+
+describe('getVitestCucumberConfiguration', () => {
+    it('default configuration', () => {
+        expect(getVitestCucumberConfiguration()).toEqual({
+            language: 'en',
+            excludeTags: ['ignore'],
+        })
+    })
+
+    it('full configuration', () => {
+        const config = {
+            language: 'fr',
+            excludeTags: ['beta'],
+        }
+
+        expect(getVitestCucumberConfiguration(config)).toEqual({
+            language: 'fr',
+            excludeTags: ['beta'],
+        })
+    })
+})
+
+describe('setVitestCucumberConfiguration', () => {
+    it('empty configuration should set the default configuration', () => {
+        const config = {}
+
+        setVitestCucumberConfiguration(config)
+
+        expect(getVitestCucumberConfiguration()).toEqual({
+            language: 'en',
+            excludeTags: ['ignore'],
+        })
+    })
+
+    it('custom configuration', () => {
+        const config = {
+            language: 'fr',
+            excludeTags: ['beta'],
+        }
+
+        setVitestCucumberConfiguration(config)
+
+        expect(getVitestCucumberConfiguration()).toEqual({
+            language: 'fr',
+            excludeTags: ['beta'],
+        })
+    })
+
+    it('override configuration defaults to empty configuration', () => {
+        const config1 = {
+            excludeTags: ['beta'],
+        }
+
+        const config2 = {
+            language: 'fr',
+        }
+
+        setVitestCucumberConfiguration(config1)
+        setVitestCucumberConfiguration(config2)
+
+        expect(getVitestCucumberConfiguration()).toEqual({
+            language: 'fr',
+            excludeTags: ['ignore'],
+        })
+    })
+})

--- a/src/vitest/__tests__/exclude-tags.spec.ts
+++ b/src/vitest/__tests__/exclude-tags.spec.ts
@@ -8,7 +8,7 @@ describe(`Ignore scenario with a tag`, async () => {
         `    Scenario: Simple scenario`,
         `        Given vitest-cucumber is running`,
         `        Then  It check I am executed`,
-        `    @ignored`,
+        `    @beta`,
         `    Scenario: Ignored scenario`,
         `        Given vitest-cucumber is running`,
         `        Then  Don't check if I am called    `,
@@ -24,7 +24,7 @@ describe(`Ignore scenario with a tag`, async () => {
                 expect(
                     feature
                         .getScenarioByName(`Ignored scenario`)
-                        ?.matchTags([`ignored`]),
+                        ?.matchTags([`beta`]),
                 ).toBe(true)
             })
             Scenario(`Simple scenario`, ({ Given, Then }) => {
@@ -32,7 +32,7 @@ describe(`Ignore scenario with a tag`, async () => {
                 Then(`It check I am executed`, () => {})
             })
         },
-        { excludeTags: [`ignored`] },
+        { excludeTags: [`beta`] },
     )
 })
 
@@ -130,7 +130,7 @@ describe(`excludeTags`, () => {
         const feature = FeatureContentReader.fromString([
             `Feature: excludeTags default value`,
             `   Rule: sample rule`,
-            `       Scenario: excludeTags is optionnal`,
+            `       Scenario: excludeTags is optional`,
             `           Given I have no tags`,
             `           Then  So I'm called`,
         ]).parseContent()
@@ -140,11 +140,11 @@ describe(`excludeTags`, () => {
 
         describeFeature(feature, (f) => {
             f.AfterAllScenarios(() => {
-                expect(featureCheck).toHaveBeenCalledWith([])
-                expect(ruleCheck).toHaveBeenCalledWith([])
+                expect(featureCheck).toHaveBeenCalledWith(['ignore'])
+                expect(ruleCheck).toHaveBeenCalledWith(['ignore'])
             })
             f.Rule(`sample rule`, (r) => {
-                r.RuleScenario(`excludeTags is optionnal`, (s) => {
+                r.RuleScenario(`excludeTags is optional`, (s) => {
                     s.Given(`I have no tags`, () => {})
                     s.Then(`So I'm called`, () => {})
                 })

--- a/src/vitest/configuration.ts
+++ b/src/vitest/configuration.ts
@@ -1,0 +1,31 @@
+export type VitestCucumberOptions = {
+    language?: string
+    excludeTags?: string[]
+}
+
+export type RequiredVitestCucumberOptions = Required<VitestCucumberOptions>
+
+const defaultConfiguration: VitestCucumberOptions = {
+    language: 'en',
+    excludeTags: ['ignore'],
+}
+
+let globalConfiguration: VitestCucumberOptions = {} as VitestCucumberOptions
+
+export const getVitestCucumberConfiguration = (
+    options?: VitestCucumberOptions,
+) => {
+    const mergedOptions = {
+        ...defaultConfiguration,
+        ...globalConfiguration,
+        ...(options || {}),
+    }
+
+    return mergedOptions as RequiredVitestCucumberOptions
+}
+
+export const setVitestCucumberConfiguration = (
+    options: VitestCucumberOptions,
+) => {
+    globalConfiguration = options
+}

--- a/src/vitest/describe-feature.ts
+++ b/src/vitest/describe-feature.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe } from 'vitest'
 import type { Feature } from '../parser/models/feature'
 import type { Example } from '../parser/models/scenario'
+import { getVitestCucumberConfiguration } from './configuration'
 import { createBackgroundDescribeHandler } from './describe/describeBackground'
 import { createScenarioDescribeHandler } from './describe/describeScenario'
 import { createScenarioOutlineDescribeHandler } from './describe/describeScenarioOutline'
@@ -32,7 +33,9 @@ export function describeFeature(
     let afterAllScenarioHook: () => MaybePromise = () => {}
     let afterEachScenarioHook: () => MaybePromise = () => {}
 
-    const excludeTags = describeFeatureOptions?.excludeTags || []
+    const excludeTags =
+        describeFeatureOptions?.excludeTags ||
+        getVitestCucumberConfiguration().excludeTags
 
     const describeScenarios: DescribesToRun = []
     const describeRules: DescribesToRun = []

--- a/src/vitest/load-feature.ts
+++ b/src/vitest/load-feature.ts
@@ -3,6 +3,7 @@ import callsites from 'callsites'
 import type { Feature } from '../parser/models/feature'
 import type { ParserOptions } from '../parser/parser'
 import { FeatureFileReader } from '../parser/readfile'
+import { getVitestCucumberConfiguration } from './configuration'
 
 function getCallerPath(): string | null {
     const { 2: callerFilePath } = callsites()
@@ -21,7 +22,7 @@ export async function loadFeature(
     const [feature] = await FeatureFileReader.fromPath({
         featureFilePath,
         callerFileDir,
-        options,
+        options: getVitestCucumberConfiguration(options),
     }).parseFile()
 
     return feature


### PR DESCRIPTION
* Export a new function `setVitestCucumberConfiguration` to let users set a global configuration for the project, usually executed in a `setupTests.ts` file in a Vite project
* Currently only hold `excludeTags` so set a default tag exclusion for every feature/scenarii
* Set default tag exclusion to exclude `@ignore`

Note: The default excluded tag is `@ignored` instead of `undefined` (from other js test library) to mimic the behavior of SpecFlow (see https://docs.specflow.org/projects/specflow/en/latest/Gherkin/Gherkin-Reference.html#tags). This is more opinionated but IMO I find it better this way in order to avoid defining a default tag exclusion ourself...

Note 2: The current options pattern can be extended to host other variables in the future (e.g. `indludedTags`, `loadRelativePath`, etc...)