### PR TITLE
refactor: improve gherkin parser logic

### DIFF
--- a/src/__mocks__/FeatureContentReader.spec.ts
+++ b/src/__mocks__/FeatureContentReader.spec.ts
@@ -22,7 +22,7 @@ export class FeatureContentReader {
             this.parser.addLine(line)
         }
 
-        const feature = this.parser.finish().at(0)
+        const feature = this.parser.finish()
 
         if (feature) {
             return feature

--- a/src/parser/__tests__/readfile.spec.ts
+++ b/src/parser/__tests__/readfile.spec.ts
@@ -4,15 +4,14 @@ import { FeatureFileReader } from '../readfile'
 
 describe(`Parse feature file`, async () => {
     const path = `src/parser/__tests__/readline.feature`
-    const features = await FeatureFileReader.fromPath({
+    const feature = await FeatureFileReader.fromPath({
         featureFilePath: path,
     }).parseFile()
 
-    const [feature] = features
     const [scenario] = feature.scenarii
 
     test(`One feature should be parsed`, () => {
-        expect(features.length).toEqual(1)
+        expect(feature).not.toBeNull()
         expect(feature.name).toEqual(`Use Gherkin in my unit tests`)
     })
 

--- a/src/parser/readfile.ts
+++ b/src/parser/readfile.ts
@@ -39,7 +39,7 @@ export class FeatureFileReader {
         return featureFilePath
     }
 
-    public async parseFile(): Promise<Feature[]> {
+    public async parseFile(): Promise<Feature> {
         if (!fs.existsSync(this.path)) {
             throw new FeatureFileNotFoundError(this.path).message
         }

--- a/src/vitest/load-feature.ts
+++ b/src/vitest/load-feature.ts
@@ -18,7 +18,7 @@ export async function loadFeature(
 ): Promise<Feature> {
     const callerFileDir = getCallerPath()
 
-    const [feature] = await FeatureFileReader.fromPath({
+    const feature = await FeatureFileReader.fromPath({
         featureFilePath,
         callerFileDir,
         options,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,8 @@
             "es2015"
         ],
         "resolveJsonModule": true,
+        "emitDecoratorMetadata": true,
+        "experimentalDecorators": true,
         "module": "ESNext",
         "moduleResolution": "node",
         "outDir": "./dist",


### PR DESCRIPTION
- use decorators
- split `addLine` by Gherkin keywords
- return only one `Feature` instead of `Feature[]`