### PR TITLE
feat: improve tag filtering

### DIFF
--- a/src/parser/__tests__/model.spec.ts
+++ b/src/parser/__tests__/model.spec.ts
@@ -410,13 +410,45 @@ describe(`Models`, () => {
     })
 
     describe(`Taggable`, () => {
-        test(`check if Taggable match tags`, () => {
-            const scenario = new Scenario(`test`)
+        const scenario = new Scenario(`test`)
+
+        describe('scenario without tag', () => {
+            test(`false if not present`, () => {
+                expect(scenario.matchTags([`test`])).toBe(false)
+            })
+        })
+
+        describe('scenario with a single tag', () => {
             scenario.tags = [`vitests`]
 
-            expect(scenario.matchTags([`test`])).toBe(false)
-            expect(scenario.matchTags([`vitests`])).toBe(true)
-            expect(scenario.matchTags([`vitests`, `another`])).toBe(true)
+            test(`false if not matching`, () => {
+                expect(scenario.matchTags([`test`])).toBe(false)
+            })
+            test(`true if one tag matches`, () => {
+                expect(scenario.matchTags([`vitests`, `another`])).toBe(true)
+            })
+        })
+
+        describe('scenario with multiple tags', () => {
+            scenario.tags = [`vitests`, `another`]
+
+            test(`true if at least one tag matches`, () => {
+                expect(scenario.matchTags([`vitests`, `test`])).toBe(true)
+            })
+            test(`true if all tags matches`, () => {
+                expect(scenario.matchTags([`vitests`, `another`])).toBe(true)
+            })
+            test(`false if no tag match`, () => {
+                expect(scenario.matchTags([`test`])).toBe(false)
+            })
+            test(`false if 'AND' operation does not match`, () => {
+                const operation = [`vitests`, `test`]
+                expect(scenario.matchTags([operation])).toBe(false)
+            })
+            test(`true if 'AND' operation does match`, () => {
+                const operation = [`vitests`, `another`]
+                expect(scenario.matchTags([operation])).toBe(true)
+            })
         })
     })
 

--- a/src/parser/__tests__/model.spec.ts
+++ b/src/parser/__tests__/model.spec.ts
@@ -83,7 +83,7 @@ describe(`Models`, () => {
             secondRule.isCalled = false
             const uncalledRuleWithTag = new Rule(`with tag`)
             uncalledRuleWithTag.isCalled = true
-            uncalledRuleWithTag.tags.push(`ignore`)
+            uncalledRuleWithTag.tags.add(`ignore`)
 
             feature.rules.push(rule)
             expect(
@@ -113,7 +113,7 @@ describe(`Models`, () => {
         test(`Throw an error if a Rule isn't called`, () => {
             const feature = new Feature(`test`)
             const rule = new Rule(`rule`)
-            rule.tags.push(`ignore`)
+            rule.tags.add(`ignore`)
 
             feature.rules.push(rule)
 
@@ -419,7 +419,7 @@ describe(`Models`, () => {
         })
 
         describe('scenario with a single tag', () => {
-            scenario.tags = [`vitests`]
+            scenario.tags = new Set([`vitests`])
 
             test(`false if not matching`, () => {
                 expect(scenario.matchTags([`test`])).toBe(false)
@@ -430,7 +430,7 @@ describe(`Models`, () => {
         })
 
         describe('scenario with multiple tags', () => {
-            scenario.tags = [`vitests`, `another`]
+            scenario.tags = new Set([`vitests`, `another`])
 
             test(`true if at least one tag matches`, () => {
                 expect(scenario.matchTags([`vitests`, `test`])).toBe(true)

--- a/src/parser/__tests__/model.spec.ts
+++ b/src/parser/__tests__/model.spec.ts
@@ -86,16 +86,31 @@ describe(`Models`, () => {
             uncalledRuleWithTag.tags.push(`ignore`)
 
             feature.rules.push(rule)
-            expect(feature.getFirstRuleNotCalled([])).toBeUndefined()
+            expect(
+                feature.getFirstRuleNotCalled({
+                    includeTags: [],
+                    excludeTags: [],
+                }),
+            ).toBeUndefined()
 
             feature.rules.push(uncalledRuleWithTag)
-            expect(feature.getFirstRuleNotCalled([`ignore`])).toBeUndefined()
+            expect(
+                feature.getFirstRuleNotCalled({
+                    includeTags: [],
+                    excludeTags: [`ignore`],
+                }),
+            ).toBeUndefined()
 
             feature.rules.push(secondRule)
-            expect(feature.getFirstRuleNotCalled([])).toEqual(secondRule)
+            expect(
+                feature.getFirstRuleNotCalled({
+                    includeTags: [],
+                    excludeTags: [],
+                }),
+            ).toEqual(secondRule)
         })
 
-        test(`Trhow an error if a Rule isn't called`, () => {
+        test(`Throw an error if a Rule isn't called`, () => {
             const feature = new Feature(`test`)
             const rule = new Rule(`rule`)
             rule.tags.push(`ignore`)
@@ -103,21 +118,40 @@ describe(`Models`, () => {
             feature.rules.push(rule)
 
             expect(() => {
-                feature.checkUncalledRule([])
+                feature.checkUncalledRule({
+                    includeTags: [],
+                    excludeTags: [],
+                })
             }).toThrowError(new RuleNotCalledError(rule))
 
             expect(() => {
-                feature.checkUncalledRule([`test`])
+                feature.checkUncalledRule({
+                    includeTags: [],
+                    excludeTags: [`test`],
+                })
             }).toThrowError(new RuleNotCalledError(rule))
 
             expect(() => {
-                feature.checkUncalledRule([`ignore`])
+                feature.checkUncalledRule({
+                    includeTags: [`ignore`],
+                    excludeTags: [],
+                })
+            }).toThrowError(new RuleNotCalledError(rule))
+
+            expect(() => {
+                feature.checkUncalledRule({
+                    includeTags: [],
+                    excludeTags: [`ignore`],
+                })
             }).not.toThrowError()
 
             rule.isCalled = true
 
             expect(() => {
-                feature.checkUncalledRule([])
+                feature.checkUncalledRule({
+                    includeTags: [],
+                    excludeTags: [],
+                })
             }).not.toThrowError()
         })
 

--- a/src/parser/__tests__/parser.spec.ts
+++ b/src/parser/__tests__/parser.spec.ts
@@ -371,8 +371,8 @@ describe(`GherkinParser`, () => {
         const [oneTag, manyLineTags, oneLineTags] = currentFeature.scenarii
 
         expect(oneTag.tags).toContain(`example`)
-        expect(manyLineTags.tags).toEqual([`example`, `awesome`, `again`])
-        expect(oneLineTags.tags).toEqual([`example`, `awesome`, `again`])
+        expect([...manyLineTags.tags]).toEqual([`example`, `awesome`, `again`])
+        expect([...oneLineTags.tags]).toEqual([`example`, `awesome`, `again`])
     })
 
     it(`should ignore tags without @`, () => {
@@ -386,8 +386,8 @@ describe(`GherkinParser`, () => {
         const currentFeature = getCurrentFeaut(parser)
         const [noTag, twoTags] = currentFeature.scenarii
 
-        expect(noTag.tags.length).toBe(0)
-        expect(twoTags.tags).toEqual([`example`, `again`])
+        expect(noTag.tags.size).toBe(0)
+        expect([...twoTags.tags]).toEqual([`example`, `again`])
     })
 
     it(`should be able to add tag to Feature`, () => {

--- a/src/parser/models/Taggable.ts
+++ b/src/parser/models/Taggable.ts
@@ -1,7 +1,28 @@
+import type { TagFilterItem } from '../../vitest/configuration'
+
+const matchFilter = (filterItem: TagFilterItem, tags: string[]) => {
+    if (Array.isArray(filterItem)) {
+        return filterItem.every((item) => tags.includes(item))
+    }
+
+    return tags.some((tag) => {
+        return filterItem === tag
+    })
+}
+
 export abstract class Taggable {
     public tags: string[] = []
 
-    public matchTags(tags: string[]): boolean {
-        return this.tags.some((tag) => tags.includes(tag))
+    /**
+     * Simple matching filter mostly following the cucumber expression tag rules,
+     * e.g. `[["alpha", "beta"], "vitests", "another"]`
+     * will be equivalent to:
+
+     * (`@alpha` and `@beta`) or `@vitests` or `@another`
+     */
+    public matchTags(filterItems: TagFilterItem[]): boolean {
+        return filterItems.some((filterItem) =>
+            matchFilter(filterItem, this.tags),
+        )
     }
 }

--- a/src/parser/models/Taggable.ts
+++ b/src/parser/models/Taggable.ts
@@ -1,17 +1,15 @@
 import type { TagFilterItem } from '../../vitest/configuration'
 
-const matchFilter = (filterItem: TagFilterItem, tags: string[]) => {
+const matchFilter = (filterItem: TagFilterItem, tags: Set<string>) => {
     if (Array.isArray(filterItem)) {
-        return filterItem.every((item) => tags.includes(item))
+        return filterItem.every((item) => tags.has(item))
     }
 
-    return tags.some((tag) => {
-        return filterItem === tag
-    })
+    return tags.has(filterItem)
 }
 
 export abstract class Taggable {
-    public tags: string[] = []
+    public tags = new Set<string>()
 
     /**
      * Simple matching filter mostly following the cucumber expression tag rules,

--- a/src/parser/models/feature.ts
+++ b/src/parser/models/feature.ts
@@ -1,4 +1,5 @@
 import { FeatureUknowRuleError, RuleNotCalledError } from '../../errors/errors'
+import type { RequiredDescribeFeatureOptions } from '../../vitest/describe-feature'
 import { Rule } from './Rule'
 import { ScenarioParent } from './ScenarioParent'
 
@@ -14,9 +15,15 @@ export class Feature extends ScenarioParent {
         return this.rules.find((rule) => rule.name === name)
     }
 
-    public getFirstRuleNotCalled(tags: string[]): Rule | undefined {
+    public getFirstRuleNotCalled(
+        options: RequiredDescribeFeatureOptions,
+    ): Rule | undefined {
         return this.rules.find(
-            (rule) => rule.isCalled === false && rule.matchTags(tags) === false,
+            (rule) =>
+                rule.isCalled === false &&
+                (options.includeTags.length <= 0 ||
+                    rule.matchTags(options.includeTags) === true) &&
+                rule.matchTags(options.excludeTags) === false,
         )
     }
 
@@ -24,8 +31,8 @@ export class Feature extends ScenarioParent {
         return this.rules.some((rule) => rule.isCalled === true)
     }
 
-    public checkUncalledRule(tags: string[]) {
-        const uncalled = this.getFirstRuleNotCalled(tags)
+    public checkUncalledRule(options: RequiredDescribeFeatureOptions) {
+        const uncalled = this.getFirstRuleNotCalled(options)
 
         if (uncalled) {
             throw new RuleNotCalledError(uncalled)

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -329,7 +329,9 @@ export class GherkinParser {
 
     private addTagToParent(parent: Taggable) {
         if (this.lastTags.length > 0) {
-            parent.tags.push(...this.lastTags)
+            for (const tag of this.lastTags) {
+                parent.tags.add(tag)
+            }
             this.lastTags = []
         }
     }

--- a/src/vitest/__tests__/configuration.spec.ts
+++ b/src/vitest/__tests__/configuration.spec.ts
@@ -40,6 +40,7 @@ describe('getVitestCucumberConfiguration', () => {
     it('default configuration', () => {
         expect(getVitestCucumberConfiguration()).toEqual({
             language: 'en',
+            includeTags: [],
             excludeTags: ['ignore'],
         })
     })
@@ -47,11 +48,13 @@ describe('getVitestCucumberConfiguration', () => {
     it('full configuration', () => {
         const config = {
             language: 'fr',
+            includeTags: ['alpha'],
             excludeTags: ['beta'],
         }
 
         expect(getVitestCucumberConfiguration(config)).toEqual({
             language: 'fr',
+            includeTags: ['alpha'],
             excludeTags: ['beta'],
         })
     })
@@ -65,6 +68,7 @@ describe('setVitestCucumberConfiguration', () => {
 
         expect(getVitestCucumberConfiguration()).toEqual({
             language: 'en',
+            includeTags: [],
             excludeTags: ['ignore'],
         })
     })
@@ -79,6 +83,7 @@ describe('setVitestCucumberConfiguration', () => {
 
         expect(getVitestCucumberConfiguration()).toEqual({
             language: 'fr',
+            includeTags: [],
             excludeTags: ['beta'],
         })
     })
@@ -97,6 +102,7 @@ describe('setVitestCucumberConfiguration', () => {
 
         expect(getVitestCucumberConfiguration()).toEqual({
             language: 'fr',
+            includeTags: [],
             excludeTags: ['ignore'],
         })
     })

--- a/src/vitest/__tests__/exclude-tags.spec.ts
+++ b/src/vitest/__tests__/exclude-tags.spec.ts
@@ -78,6 +78,40 @@ describe(`Ignore scenario with a tag`, async () => {
     )
 })
 
+describe(`Ignore scenario with a tag (alternative with an @ prefix)`, async () => {
+    const feature = FeatureContentReader.fromString([
+        `Feature: detect uncalled rules`,
+        `    Scenario: Simple scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  It check I am executed`,
+        `    @beta`,
+        `    Scenario: Ignored scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  Don't check if I am called    `,
+    ]).parseContent()
+
+    describeFeature(
+        feature,
+        ({ Scenario, AfterAllScenarios }) => {
+            AfterAllScenarios(() => {
+                expect(
+                    feature.getScenarioByName(`Ignored scenario`)?.isCalled,
+                ).toBe(false)
+                expect(
+                    feature
+                        .getScenarioByName(`Ignored scenario`)
+                        ?.matchTags([`beta`]),
+                ).toBe(true)
+            })
+            Scenario(`Simple scenario`, ({ Given, Then }) => {
+                Given(`vitest-cucumber is running`, () => {})
+                Then(`It check I am executed`, () => {})
+            })
+        },
+        { excludeTags: [`@beta`] },
+    )
+})
+
 describe(`Ignore rule with a tag`, async () => {
     const feature = FeatureContentReader.fromString([
         `Feature: detect uncalled rules`,

--- a/src/vitest/__tests__/exclude-tags.spec.ts
+++ b/src/vitest/__tests__/exclude-tags.spec.ts
@@ -2,6 +2,48 @@ import { describe, expect, vi } from 'vitest'
 import { FeatureContentReader } from '../../__mocks__/FeatureContentReader.spec'
 import { describeFeature } from '../describe-feature'
 
+describe(`Execute all scenarii if no exclusion tag`, async () => {
+    const feature = FeatureContentReader.fromString([
+        `Feature: detect uncalled rules`,
+        `    Scenario: Simple scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  It check I am executed`,
+        `    @beta`,
+        `    Scenario: Beta scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  It check I am executed    `,
+    ]).parseContent()
+
+    describeFeature(
+        feature,
+        ({ Scenario, AfterAllScenarios }) => {
+            AfterAllScenarios(() => {
+                expect(
+                    feature.getScenarioByName(`Simple scenario`)?.isCalled,
+                ).toBe(true)
+
+                expect(
+                    feature.getScenarioByName(`Beta scenario`)?.isCalled,
+                ).toBe(true)
+                expect(
+                    feature
+                        .getScenarioByName(`Beta scenario`)
+                        ?.matchTags([`beta`]),
+                ).toBe(true)
+            })
+            Scenario(`Simple scenario`, ({ Given, Then }) => {
+                Given(`vitest-cucumber is running`, () => {})
+                Then(`It check I am executed`, () => {})
+            })
+            Scenario(`Beta scenario`, ({ Given, Then }) => {
+                Given(`vitest-cucumber is running`, () => {})
+                Then(`It check I am executed`, () => {})
+            })
+        },
+        { excludeTags: [] },
+    )
+})
+
 describe(`Ignore scenario with a tag`, async () => {
     const feature = FeatureContentReader.fromString([
         `Feature: detect uncalled rules`,

--- a/src/vitest/__tests__/include-tags.spec.ts
+++ b/src/vitest/__tests__/include-tags.spec.ts
@@ -2,16 +2,16 @@ import { describe, expect, vi } from 'vitest'
 import { FeatureContentReader } from '../../__mocks__/FeatureContentReader.spec'
 import { describeFeature } from '../describe-feature'
 
-describe(`Ignore scenario with a tag`, async () => {
+describe(`Run scenario selected with a tag`, async () => {
     const feature = FeatureContentReader.fromString([
         `Feature: detect uncalled rules`,
-        `    Scenario: Simple scenario`,
-        `        Given vitest-cucumber is running`,
-        `        Then  It check I am executed`,
-        `    @beta`,
         `    Scenario: Ignored scenario`,
         `        Given vitest-cucumber is running`,
-        `        Then  Don't check if I am called    `,
+        `        Then  Don't check if I am called`,
+        `    @beta`,
+        `    Scenario: Selected scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  It check I am executed    `,
     ]).parseContent()
 
     describeFeature(
@@ -22,21 +22,24 @@ describe(`Ignore scenario with a tag`, async () => {
                     feature.getScenarioByName(`Ignored scenario`)?.isCalled,
                 ).toBe(false)
                 expect(
+                    feature.getScenarioByName(`Selected scenario`)?.isCalled,
+                ).toBe(true)
+                expect(
                     feature
-                        .getScenarioByName(`Ignored scenario`)
+                        .getScenarioByName(`Selected scenario`)
                         ?.matchTags([`beta`]),
                 ).toBe(true)
             })
-            Scenario(`Simple scenario`, ({ Given, Then }) => {
+            Scenario(`Selected scenario`, ({ Given, Then }) => {
                 Given(`vitest-cucumber is running`, () => {})
                 Then(`It check I am executed`, () => {})
             })
         },
-        { excludeTags: [`beta`] },
+        { includeTags: [`beta`] },
     )
 })
 
-describe(`Ignore rule with a tag`, async () => {
+describe(`Run rule with a tag`, async () => {
     const feature = FeatureContentReader.fromString([
         `Feature: detect uncalled rules`,
         `    @awesome`,
@@ -70,11 +73,11 @@ describe(`Ignore rule with a tag`, async () => {
                 Then(`check if I am called`, () => {})
             })
         },
-        { excludeTags: [`normal`] },
+        { includeTags: [`awesome`] },
     )
 })
 
-describe(`Ignore scenario in rule with a tag`, async () => {
+describe(`Run scenario in rule with a tag`, async () => {
     const feature = FeatureContentReader.fromString([
         `Feature: detect uncalled rules`,
         `    @awesome`,
@@ -121,16 +124,16 @@ describe(`Ignore scenario in rule with a tag`, async () => {
                 })
             })
         },
-        { excludeTags: [`ignored`] },
+        { includeTags: [`inside`] },
     )
 })
 
-describe(`excludeTags`, () => {
+describe(`includeTags`, () => {
     describe(`default value`, () => {
         const feature = FeatureContentReader.fromString([
-            `Feature: excludeTags default value`,
+            `Feature: includeTags default value`,
             `   Rule: sample rule`,
-            `       Scenario: excludeTags is optional`,
+            `       Scenario: includeTags is optional`,
             `           Given I have no tags`,
             `           Then  So I'm called`,
         ]).parseContent()
@@ -150,16 +153,16 @@ describe(`excludeTags`, () => {
                 })
             })
             f.Rule(`sample rule`, (r) => {
-                r.RuleScenario(`excludeTags is optional`, (s) => {
+                r.RuleScenario(`includeTags is optional`, (s) => {
                     s.Given(`I have no tags`, () => {})
                     s.Then(`So I'm called`, () => {})
                 })
             })
         })
     })
-    describe(`exclude Rule and Scenario`, () => {
+    describe(`include Rule and Scenario`, () => {
         const feature = FeatureContentReader.fromString([
-            `Feature: excludeTags used`,
+            `Feature: includeTags used`,
             `   @ignored-scenario`,
             `   Scenario: A Feature ignored Scenario`,
             `       Given I have a tag`,
@@ -213,8 +216,8 @@ describe(`excludeTags`, () => {
 
                     for (const fn of checks) {
                         expect(fn).toHaveBeenCalledWith({
-                            includeTags: [],
-                            excludeTags: [`ignored-scenario`, `ignored-rule`],
+                            includeTags: [`simple`],
+                            excludeTags: [],
                         })
                     }
 
@@ -250,7 +253,8 @@ describe(`excludeTags`, () => {
                 })
             },
             {
-                excludeTags: [`ignored-scenario`, `ignored-rule`],
+                includeTags: [`simple`],
+                excludeTags: [],
             },
         )
     })

--- a/src/vitest/__tests__/include-tags.spec.ts
+++ b/src/vitest/__tests__/include-tags.spec.ts
@@ -39,6 +39,43 @@ describe(`Run scenario selected with a tag`, async () => {
     )
 })
 
+describe(`Run scenario selected with a tag (alternative with an @ prefix)`, async () => {
+    const feature = FeatureContentReader.fromString([
+        `Feature: detect uncalled rules`,
+        `    Scenario: Ignored scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  Don't check if I am called`,
+        `    @beta`,
+        `    Scenario: Selected scenario`,
+        `        Given vitest-cucumber is running`,
+        `        Then  It check I am executed    `,
+    ]).parseContent()
+
+    describeFeature(
+        feature,
+        ({ Scenario, AfterAllScenarios }) => {
+            AfterAllScenarios(() => {
+                expect(
+                    feature.getScenarioByName(`Ignored scenario`)?.isCalled,
+                ).toBe(false)
+                expect(
+                    feature.getScenarioByName(`Selected scenario`)?.isCalled,
+                ).toBe(true)
+                expect(
+                    feature
+                        .getScenarioByName(`Selected scenario`)
+                        ?.matchTags([`beta`]),
+                ).toBe(true)
+            })
+            Scenario(`Selected scenario`, ({ Given, Then }) => {
+                Given(`vitest-cucumber is running`, () => {})
+                Then(`It check I am executed`, () => {})
+            })
+        },
+        { includeTags: [`@beta`] },
+    )
+})
+
 describe(`Run rule with a tag`, async () => {
     const feature = FeatureContentReader.fromString([
         `Feature: detect uncalled rules`,

--- a/src/vitest/configuration.ts
+++ b/src/vitest/configuration.ts
@@ -1,5 +1,6 @@
 export type VitestCucumberOptions = {
     language?: string
+    includeTags?: string[]
     excludeTags?: string[]
 }
 
@@ -7,6 +8,7 @@ export type RequiredVitestCucumberOptions = Required<VitestCucumberOptions>
 
 const defaultConfiguration: VitestCucumberOptions = {
     language: 'en',
+    includeTags: [],
     excludeTags: ['ignore'],
 }
 

--- a/src/vitest/configuration.ts
+++ b/src/vitest/configuration.ts
@@ -1,7 +1,9 @@
+export type TagFilterItem = string | string[]
+
 export type VitestCucumberOptions = {
     language?: string
-    includeTags?: string[]
-    excludeTags?: string[]
+    includeTags?: TagFilterItem[]
+    excludeTags?: TagFilterItem[]
 }
 
 export type RequiredVitestCucumberOptions = Required<VitestCucumberOptions>

--- a/src/vitest/describe-feature.ts
+++ b/src/vitest/describe-feature.ts
@@ -39,11 +39,12 @@ export function describeFeature(
     let afterEachScenarioHook: () => MaybePromise = () => {}
 
     const configuration = getVitestCucumberConfiguration()
-
-    const includeTags =
-        describeFeatureOptions?.includeTags || configuration.includeTags
-    const excludeTags =
-        describeFeatureOptions?.excludeTags || configuration.excludeTags
+    const options = {
+        includeTags:
+            describeFeatureOptions?.includeTags || configuration.includeTags,
+        excludeTags:
+            describeFeatureOptions?.excludeTags || configuration.excludeTags,
+    }
 
     const describeScenarios: DescribesToRun = []
     const describeRules: DescribesToRun = []
@@ -178,8 +179,8 @@ export function describeFeature(
             })
 
             currentRule
-                .checkUncalledScenario({ includeTags, excludeTags })
-                .checkUncalledBackground({ includeTags, excludeTags })
+                .checkUncalledScenario(options)
+                .checkUncalledBackground(options)
 
             describeRules.push({
                 describeTitle: currentRule.getTitle(),
@@ -230,9 +231,9 @@ export function describeFeature(
     describeFeatureCallback(descibeFeatureParams)
 
     feature
-        .checkUncalledRule({ includeTags, excludeTags })
-        .checkUncalledScenario({ includeTags, excludeTags })
-        .checkUncalledBackground({ includeTags, excludeTags })
+        .checkUncalledRule(options)
+        .checkUncalledScenario(options)
+        .checkUncalledBackground(options)
 
     describe(feature.getTitle(), async () => {
         beforeAll(async () => {

--- a/src/vitest/describe-feature.ts
+++ b/src/vitest/describe-feature.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, describe } from 'vitest'
 import type { Feature } from '../parser/models/feature'
 import type { Example } from '../parser/models/scenario'
 import {
+    type TagFilterItem,
     type VitestCucumberOptions,
     getVitestCucumberConfiguration,
 } from './configuration'
@@ -28,6 +29,23 @@ type DescribesToRun = Array<{
     describeHandler: () => void
 }>
 
+/**
+ * Extract tag filters by removing the `@` prefix if present
+ */
+const extractTagFilters = (filterItems: TagFilterItem[]): TagFilterItem[] => {
+    return filterItems.map((filterItem) => {
+        if (Array.isArray(filterItem)) {
+            return extractTagFilters(filterItem) as TagFilterItem
+        }
+
+        if (filterItem.startsWith('@')) {
+            return filterItem.replace('@', '') as TagFilterItem
+        }
+
+        return filterItem as TagFilterItem
+    })
+}
+
 export function describeFeature(
     feature: Feature,
     describeFeatureCallback: DescribeFeatureCallback,
@@ -40,10 +58,12 @@ export function describeFeature(
 
     const configuration = getVitestCucumberConfiguration()
     const options = {
-        includeTags:
+        includeTags: extractTagFilters(
             describeFeatureOptions?.includeTags || configuration.includeTags,
-        excludeTags:
+        ),
+        excludeTags: extractTagFilters(
             describeFeatureOptions?.excludeTags || configuration.excludeTags,
+        ),
     }
 
     const describeScenarios: DescribesToRun = []


### PR DESCRIPTION
* add `includeTags` from config (global or per feature) because sometimes we want to exclude/ignore scenarii by tags but sometimes we only want some specific scenarii (for example when we are working on a new feature or to test a set of repetitve failing tests)
* add ability to provide nested string[] for complex filter, kind of `AND` and `OR` (I have added a jsdoc to demonstrate how that works)
* Remove `@` suffix because we can sometimes forget it and can be cumbersome if that is not handled, small but important improvement
* Change `tags` to be a `Set<string>` to both improve performance and dedup the array of tags automatically 