### PR TITLE
fix: asterisk should only be treated as `And` step

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lefthook:prepare": "lefthook install",
     "lint": "biome check",
     "lint:fix": "biome check --write",
-    "prebuild" : "wget -q -O src/parser/lang/lang.json 'https://raw.githubusercontent.com/cucumber/gherkin/1667cf8ed6920093ccf0ad1111bceb823ae43730/gherkin-languages.json'",
+    "prebuild" : "node prebuild.js",
     "test:unit": "npm run prebuild && vitest",
     "test:silent": "npm run prebuild && vitest --silent --run",
     "test:coverage": "npm run prebuild && vitest run --coverage"

--- a/prebuild.js
+++ b/prebuild.js
@@ -1,0 +1,30 @@
+const fs = require('node:fs')
+
+async function main() {
+    const response = await fetch(
+        'https://raw.githubusercontent.com/cucumber/gherkin/1667cf8ed6920093ccf0ad1111bceb823ae43730/gherkin-languages.json',
+    )
+    const data = await response.json()
+
+    for (const detailsPropertyName in data) {
+        const details = data[detailsPropertyName]
+
+        for (const propertyName in details) {
+            if (propertyName === 'and') {
+                continue
+            }
+
+            const property = details[propertyName]
+
+            if (!Array.isArray(property)) {
+                continue
+            }
+
+            details[propertyName] = property.filter((value) => value !== '* ')
+        }
+    }
+
+    fs.writeFileSync('src/parser/lang/lang.json', JSON.stringify(data, null, 2))
+}
+
+main()

--- a/src/parser/__tests__/parser.spec.ts
+++ b/src/parser/__tests__/parser.spec.ts
@@ -101,6 +101,25 @@ describe(`GherkinParser`, () => {
         expect(currentStep.isCalled).toBeFalsy()
     })
 
+    describe('asterisk steps', () => {
+        // reference: https://cucumber.io/docs/gherkin/reference/#Asterisk
+        it(`should be able to parse asterisk as 'And' after a 'Given' line`, () => {
+            parser.addLine(`Feature: awesome feature`)
+            parser.addLine(`Scenario: Example scenario`)
+            parser.addLine(`Given I run unit tests with vitest`)
+            parser.addLine(`* I load a web page`)
+
+            const currentScenario = getCurrentScenario(parser)
+            const [_, currentStep] = currentScenario.steps
+            console.log(currentStep)
+
+            expect(currentScenario.steps.length).toEqual(2)
+            expect(currentStep.type).toEqual(StepTypes.AND)
+            expect(currentStep.details).toEqual(`I load a web page`)
+            expect(currentStep.isCalled).toBeFalsy()
+        })
+    })
+
     it(`should trim Scenario / Feature line title`, () => {
         const lineTitle = `Scenario:    remove space `
 

--- a/src/parser/__tests__/parser.spec.ts
+++ b/src/parser/__tests__/parser.spec.ts
@@ -111,7 +111,6 @@ describe(`GherkinParser`, () => {
 
             const currentScenario = getCurrentScenario(parser)
             const [_, currentStep] = currentScenario.steps
-            console.log(currentStep)
 
             expect(currentScenario.steps.length).toEqual(2)
             expect(currentStep.type).toEqual(StepTypes.AND)

--- a/src/parser/lang/SpokenParser.ts
+++ b/src/parser/lang/SpokenParser.ts
@@ -5,12 +5,6 @@ import availableLanguages from './lang.json'
 type Languages = keyof typeof availableLanguages
 type GherkinLanguageDetails = (typeof availableLanguages)['en']
 
-type StringArrayProps<T> = {
-    [K in keyof T]: T[K] extends string[] ? K : never
-}[keyof T]
-
-type StringArrayKeys = StringArrayProps<GherkinLanguageDetails>
-
 type LineDetails = { keyword: string; title: string }
 
 // biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
@@ -20,23 +14,6 @@ export abstract class SpokenParserFactory {
             lang in availableLanguages
                 ? availableLanguages[lang as Languages]
                 : availableLanguages.en
-
-        for (const propertyName in details) {
-            if (propertyName === 'and') {
-                continue
-            }
-
-            const property =
-                details[propertyName as keyof GherkinLanguageDetails]
-
-            if (!Array.isArray(property)) {
-                continue
-            }
-
-            details[propertyName as StringArrayKeys] = property.filter(
-                (value) => value !== '* ',
-            )
-        }
 
         return new SpokenParser(details)
     }

--- a/src/parser/lang/SpokenParser.ts
+++ b/src/parser/lang/SpokenParser.ts
@@ -1,38 +1,44 @@
 import { SpokenKeywordError } from '../../errors/errors'
 import { StepTypes } from '../models/step'
-import avalaibleLanguages from './lang.json'
+import availableLanguages from './lang.json'
 
-type GherkinLanguageDetails = {
-    and: string[]
-    background: string[]
-    but: string[]
-    examples: string[]
-    feature: string[]
-    given: string[]
-    rule: string[]
-    scenario: string[]
-    scenarioOutline: string[]
-    then: string[]
-    when: string[]
-}
+type Languages = keyof typeof availableLanguages
+type GherkinLanguageDetails = (typeof availableLanguages)['en']
+
+type StringArrayProps<T> = {
+    [K in keyof T]: T[K] extends string[] ? K : never
+}[keyof T]
+
+type StringArrayKeys = StringArrayProps<GherkinLanguageDetails>
 
 type LineDetails = { keyword: string; title: string }
-
-type GherkinLanguage = {
-    [key: string]: GherkinLanguageDetails
-}
 
 // biome-ignore lint/complexity/noStaticOnlyClass: <explanation>
 export abstract class SpokenParserFactory {
     public static fromLang(lang: string): SpokenParser {
-        const details = (avalaibleLanguages as GherkinLanguage)[lang]
-        const defaultDetails = (avalaibleLanguages as GherkinLanguage).en
+        const details =
+            lang in availableLanguages
+                ? availableLanguages[lang as Languages]
+                : availableLanguages.en
 
-        if (details) {
-            return new SpokenParser(details)
+        for (const propertyName in details) {
+            if (propertyName === 'and') {
+                continue
+            }
+
+            const property =
+                details[propertyName as keyof GherkinLanguageDetails]
+
+            if (!Array.isArray(property)) {
+                continue
+            }
+
+            details[propertyName as StringArrayKeys] = property.filter(
+                (value) => value !== '* ',
+            )
         }
 
-        return new SpokenParser(defaultDetails)
+        return new SpokenParser(details)
     }
 }
 


### PR DESCRIPTION
Per the doc, `*` should be treated as `And`.
So, filtering out all the gherkin language spec arrays instead of  `and`.

Reworked the original solution by writing a custom `prebuild` script.

What do you think?