### PR TITLE
fix: re-use module as entry point for types

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     ".": "./dist/src/module.js",
     "./browser": "./dist/src/browser/index.js"
   },
-  "types": "./dist/src/types.d.ts",
+  "types": "./dist/src/module.d.ts",
   "files": [
     "dist"
   ],

--- a/src/module.ts
+++ b/src/module.ts
@@ -12,3 +12,4 @@ export {
     defineParameterExpression,
     type CustomParameterExpressionArgs,
 } from './parser/expression/custom'
+export { StepTest, FeatureDescriibeCallbackParams } from "./vitest/types"

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,2 +1,0 @@
-export * from "./module";
-export { StepTest, FeatureDescriibeCallbackParams } from "./vitest/types"


### PR DESCRIPTION
Much appreciated for the last PR being merged.
Testing locally 'types.d.ts' should have solved the problem but it fixed it partially.

I see you have a `  "main": "dist/src/module.js"` and ` export : { ".": "./dist/src/module.js" }`, and for some reason typescript did not picked up the types file properly.

In a way to solve that, I dropped the types.ts file and continued using your module file.

Thanks in advance and sorry for the double PR.